### PR TITLE
Add support for MailMate

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Thunderbird | Yes | Yes | No | Yes | Yes | Yes | --
 Missive | Yes | Yes | No | No | Yes | No | --
 HubSpot | Yes | Yes | Yes | Yes | Yes | Yes | --
 IONOS by 1 & 1 | ? | Yes | ? | ? | Yes | ? | --
+MailMate | Yes | Yes | No | No | Yes | No | --
 
 ## Contributing
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -16,7 +16,8 @@ var LINE_REGEXES = [
   "original_subject_lax",
   "original_to",
   "original_reply_to",
-  "original_cc"
+  "original_cc",
+  "original_date"
 ];
 
 var REGEXES = {
@@ -44,7 +45,7 @@ var REGEXES = {
     /^VL:(.*)/m, // New Outlook 2019 (fi)
     /^Videresend:(.*)/m, // New Outlook 2019 (no)
     /^İLT:(.*)/m, // New Outlook 2019 (tr)
-    /^Fwd:(.*)/m // Gmail (all locales), Thunderbird (all locales), Missive (en)
+    /^Fwd:(.*)/m // Gmail (all locales), Thunderbird (all locales), Missive (en), MailMate (en)
   ],
 
   separator : [
@@ -71,6 +72,7 @@ var REGEXES = {
     /^>?\s*İleti başlangıcı\s?:/m, // Apple Mail (tr)
     /^>?\s*Початок листа, що пересилається\s?:/m, // Apple Mail (uk)
     /^\s*-{8,10}\s*Forwarded message\s*-{8,10}\s*/m, // Gmail (all locales), Missive (en), HubSpot (en)
+    /^Forwarded message:/m, // Mailmate
     /^\s*_{32}\s*$/m, // Outlook Live / 365 (all locales)
     /^\s?Dne\s?.+\,\s?.+\s*[\[|<].+[\]|>]\s?napsal\(a\)\s?:/m, // Outlook 2019 (cz)
     /^\s?D.\s?.+\s?skrev\s?\".+\"\s*[\[|<].+[\]|>]\s?:/m, // Outlook 2019 (da)
@@ -642,7 +644,8 @@ class Parser {
       this.__regexes.original_subject_line,
       this.__regexes.original_cc_line,
       this.__regexes.original_to_line,
-      this.__regexes.original_reply_to_line
+      this.__regexes.original_reply_to_line,
+      this.__regexes.original_date_line
     ];
 
     for (var _i = 0; _i < _regexes.length; _i++) {

--- a/test/fixtures/mailmate_en_body.txt
+++ b/test/fixtures/mailmate_en_body.txt
@@ -1,0 +1,12 @@
+Forwarded message:
+
+> From: John Doe <john.doe@acme.com>
+> To: bessie.berry@acme.com
+> Cc: Walter Sheltan <walter.sheltan@acme.com>, Nicholas <nicholas@globex.corp>
+> Subject: Integer consequat non purus
+> Date: Wed, 27 Oct 2021 09:31:00 +0000
+>
+> Aenean quis diam urna. Maecenas eleifend vulputate ligula ac consequat. Pellentesque cursus tincidunt mauris non venenatis.
+Sed nec facilisis tellus. Nunc eget eros quis ex congue iaculis nec quis massa. Morbi in nisi tincidunt, euismod ante eget, eleifend nisi.
+>
+> Praesent ac ligula orci. Pellentesque convallis suscipit mi, at congue massa sagittis eget.

--- a/test/fixtures/mailmate_en_body_variant_1.txt
+++ b/test/fixtures/mailmate_en_body_variant_1.txt
@@ -1,0 +1,11 @@
+Forwarded message:
+
+> From: John Doe <john.doe@acme.com>
+> To: bessie.berry@acme.com, suzanne@globex.corp
+> Subject: Integer consequat non purus
+> Date: Wed, 27 Oct 2021 09:31:00 +0000
+>
+> Aenean quis diam urna. Maecenas eleifend vulputate ligula ac consequat. Pellentesque cursus tincidunt mauris non venenatis.
+Sed nec facilisis tellus. Nunc eget eros quis ex congue iaculis nec quis massa. Morbi in nisi tincidunt, euismod ante eget, eleifend nisi.
+>
+> Praesent ac ligula orci. Pellentesque convallis suscipit mi, at congue massa sagittis eget.

--- a/test/fixtures/mailmate_en_body_variant_2.txt
+++ b/test/fixtures/mailmate_en_body_variant_2.txt
@@ -1,0 +1,16 @@
+Praesent suscipit egestas hendrerit.
+
+Aliquam eget dui dui.
+
+Forwarded message:
+
+> From: John Doe <john.doe@acme.com>
+> To: bessie.berry@acme.com, suzanne@globex.corp
+> Cc: Walter Sheltan <walter.sheltan@acme.com>, Nicholas <nicholas@globex.corp>
+> Subject: Integer consequat non purus
+> Date: Wed, 27 Oct 2021 09:31:00 +0000
+>
+> Aenean quis diam urna. Maecenas eleifend vulputate ligula ac consequat. Pellentesque cursus tincidunt mauris non venenatis.
+Sed nec facilisis tellus. Nunc eget eros quis ex congue iaculis nec quis massa. Morbi in nisi tincidunt, euismod ante eget, eleifend nisi.
+>
+> Praesent ac ligula orci. Pellentesque convallis suscipit mi, at congue massa sagittis eget.

--- a/test/fixtures/mailmate_en_body_variant_4.txt
+++ b/test/fixtures/mailmate_en_body_variant_4.txt
@@ -1,0 +1,10 @@
+That's true!
+
+Regards,
+
+e.
+
+On July 19, 2022 at 3:36 PM, John Doe wrote:
+
+> Unicum iter ad supremum.
+>

--- a/test/index.js
+++ b/test/index.js
@@ -170,6 +170,8 @@ module.exports = {
 
         "ionos_one_and_one_en_body",
 
+        "mailmate_en_body",
+
         "missive_en_body",
 
         ["outlook_live_body", "outlook_live_cs_subject"],
@@ -313,6 +315,7 @@ module.exports = {
         "apple_mail_en_body_variant_1",
         "gmail_en_body_variant_1",
         "hubspot_en_body_variant_1",
+        "mailmate_en_body_variant_1",
         "missive_en_body_variant_1",
         ["outlook_live_en_body_variant_1", "outlook_live_en_subject"],
         ["new_outlook_2019_en_body_variant_1", "new_outlook_2019_en_subject"],
@@ -351,6 +354,7 @@ module.exports = {
         "gmail_en_body_variant_2",
         "hubspot_en_body_variant_2",
         "ionos_one_and_one_en_body_variant_2",
+        "mailmate_en_body_variant_2",
         "missive_en_body_variant_2",
         ["outlook_live_en_body_variant_2", "outlook_live_en_subject"],
         ["new_outlook_2019_en_body_variant_2", "new_outlook_2019_en_subject"],
@@ -439,6 +443,7 @@ module.exports = {
         "apple_mail_en_body_variant_4",
         "gmail_en_body_variant_4",
         "hubspot_en_body_variant_4",
+        "mailmate_en_body_variant_4",
         "missive_en_body_variant_4",
         ["outlook_live_en_body_variant_4", "outlook_live_en_subject_variant_4"],
         ["new_outlook_2019_en_body_variant_4", "new_outlook_2019_en_subject_variant_4"],


### PR DESCRIPTION
I use [MailMate](https://freron.com) as my email client, and found that the library couldn't parse messages it forwarded - largely because it puts the `Date` line last in the forwarded headers.

Seems to work with this update and the existing tests still pass, though i haven't done any work with it other than English.

Thanks for writing this!