### PR TITLE
Bump `re2` to 1.21.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "nodeunit-x": "0.15.0"
   },
   "dependencies": {
-    "re2": "1.20.7"
+    "re2": "1.21.4"
   },
   "keywords": [
     "parser",


### PR DESCRIPTION
Installing `email-forward-parser` on Node.js 22 on arm64 Darwin triggers `node-gyp` compilation due to the `re2` dependency:

<details>
<summary>Versions</summary>
<br/>

```
$ uname -sm
Darwin arm64

$ node --version
v22.8.0

$ npm --version
10.8.2
```
</details>

<details>
<summary><code>email-forward-parser</code> install output
</summary>
<br/>

```
$ npm --foreground-scripts=true install email-forward-parser@1.6.0

> re2@1.21.4 install
> install-from-cache --artifact build/Release/re2.node --host-var RE2_DOWNLOAD_MIRROR --skip-path-var RE2_DOWNLOAD_SKIP_PATH --skip-ver-var RE2_DOWNLOAD_SKIP_VER || node-gyp -j max rebuild

Trying https://github.com/uhop/node-re2/releases/download/1.21.4/darwin-arm64-127.br ...
Writing to build/Release/re2.node ...
Done.

> re2@1.20.7 install
> install-from-cache --artifact build/Release/re2.node --host-var RE2_DOWNLOAD_MIRROR --skip-path-var RE2_DOWNLOAD_SKIP_PATH --skip-ver-var RE2_DOWNLOAD_SKIP_VER || npm run rebuild

Trying https://github.com/uhop/node-re2/releases/download/1.20.7/darwin-arm64-127.br ...
Trying https://github.com/uhop/node-re2/releases/download/1.20.7/darwin-arm64-127.gz ...
Building locally ...

> re2@1.20.7 rebuild
> node-gyp rebuild

...
```
</details>

This is because the [`re2@1.20.7`](https://github.com/uhop/node-re2/releases/tag/1.20.7) GitHub release does not contain a pre-compiled binding for Node.js 22 on Darwin arm64.

However, upgrading the `re2` dependency to the latest version (`re2@1.21.4`) still passes the `email-forward-parser` tests on Node.js 18, 20, 22, _and_ obviates the need for `node-gyp` when installing `email-forward-parser`:

```
$ npm --foreground-scripts=true install github:mxxk-forks/email-forward-parser#bump-re2

> re2@1.21.4 install
> install-from-cache --artifact build/Release/re2.node --host-var RE2_DOWNLOAD_MIRROR --skip-path-var RE2_DOWNLOAD_SKIP_PATH --skip-ver-var RE2_DOWNLOAD_SKIP_VER || node-gyp -j max rebuild

Trying https://github.com/uhop/node-re2/releases/download/1.21.4/darwin-arm64-127.br ...
Writing to build/Release/re2.node ...
Done.

added 105 packages, and audited 107 packages in 6s

14 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

> [!NOTE]
>
> P.S. Thank you for maintaining this repo, @eliottvincent!