### PR TITLE
Bump `re2` and relax version constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "nodeunit-x": "0.15.0"
   },
   "dependencies": {
-    "re2": "1.21.4"
+    "re2": "^1.22.1"
   },
   "keywords": [
     "parser",


### PR DESCRIPTION
Hi there, 👋 thank you again for maintaining `email-forward-parser`; it’s been a really helpful library for us. I wanted to bump the `re2` version and revisit the topic of relaxing its version constraint.

We’ve run into repeated issues when upgrading Node.js because this package currently pins `re2` to a specific version that often lacks prebuilt binaries for newer Node releases. For example:

- When moving from Node v20 → v22, `email-forward-parser` pinned `re2@1.20.7`, which didn’t have binaries for Node 22. That led to us opening https://github.com/crisp-oss/email-forward-parser/pull/19.
- Now, upgrading from Node v22 → v24, we’re hitting the same issue: `re2@1.21.4` doesn’t yet provide binaries for Node 24.

I completely understand the earlier point (https://github.com/crisp-oss/email-forward-parser/pull/19#discussion_r1745443168) about wanting to control dependency updates and ensure nothing breaks; that’s a very reasonable consideration. However, in this case, `re2` follows semantic versioning closely and has a fairly stable API surface. Using a looser constraint (like `^1.22.1` or `~1.22.1`) would still protect against breaking changes while avoiding compatibility blocks when Node releases new major versions.

This small change would make `email-forward-parser` much more future-friendly for downstream consumers without sacrificing your control over dependency safety.

Thanks again for your time and for maintaining this project!